### PR TITLE
Initialise bignums in modp_init (Fix unintialised bignum pointer)

### DIFF
--- a/iked/dh.c
+++ b/iked/dh.c
@@ -440,7 +440,7 @@ dh_create_shared(struct group *group, uint8_t *secret, uint8_t *exchange)
 int
 modp_init(struct group *group)
 {
-	BIGNUM	*g, *p;
+	BIGNUM	*g = 0, *p = 0;
 	DH	*dh;
 
 	dh = DH_new();


### PR DESCRIPTION
BN_hex2bn() will only create a new bignum if the pointer given to it is null,
otherwise it assumes it is given an existing bignum to reuse.

This was causing the ikev2 slave to crash every time on sa init for me since upgrading to FreeBSD 12.1 with OpenSSL 1.1d.

"BN_hex2bn() converts the string str containing a hexadecimal number to a BIGNUM and stores it in **bn. If *bn is NULL , a new BIGNUM is created. If bn is NULL , it only computes the number's length in hexadecimal digits. If the string starts with '-', the number is negative. BN_dec2bn() is the same using the decimal system."

^https://linux.die.net/man/3/bn_hex2bn